### PR TITLE
Enabling Team Foundation build

### DIFF
--- a/Build/Common.Build.settings
+++ b/Build/Common.Build.settings
@@ -114,9 +114,6 @@
     
     <!-- Features default to true for release builds -->
     <FeatureAzureRemoteDebug>$(ReleaseBuild)</FeatureAzureRemoteDebug>
-    
-    <!-- Enable features based on VS versions -->
-    <FeatureAzureRemoteDebug Condition="$(VSMajorVersion) > 12 or ($(VSMajorVersion) == 12 and $(VSUpdateVersion) >= 30723)">true</FeatureAzureRemoteDebug>
   </PropertyGroup>
   
   <ItemDefinitionGroup>

--- a/Setup/dirs.proj
+++ b/Setup/dirs.proj
@@ -4,7 +4,8 @@
   
   <ItemGroup>
     <ProjectFile Include="..\Product\NodejsUwp.csproj"/>
-	<ProjectFile Include="setup.proj"/>
+	<!-- Uncomment if building with BuildRelease.ps1 script -->
+	<!--<ProjectFile Include="setup.proj"/>-->
   </ItemGroup>
 
   <Import Project="$(TargetsPath)\Common.Build.Traversal.targets" />

--- a/TFbuildstub.cs
+++ b/TFbuildstub.cs
@@ -1,0 +1,9 @@
+// This stub is used in Team Foundation project files to successfully build releases
+
+using System;
+
+class HelloWorld {
+    static void Main() {
+        Console.WriteLine("buildstub: no-op");
+    }
+}

--- a/TFdevicefiles.proj
+++ b/TFdevicefiles.proj
@@ -1,0 +1,44 @@
+<!-- This project is used by Team Foundation build. It will build the Node.js UWP binaries that are deployed to devices -->
+
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<OutputPath>bin\</OutputPath>
+	</PropertyGroup>
+	
+	<ItemGroup>
+		<Compile Include="TFbuildstub.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<FilesToSign Include="$(OutDir)DeviceFiles\arm\nodeuwp.dll">
+			<Authenticode>Microsoft</Authenticode>
+		</FilesToSign>
+		<FilesToSign Include="$(OutDir)DeviceFiles\arm\uwp.node">
+			<Authenticode>Microsoft</Authenticode>
+		</FilesToSign>
+		<FilesToSign Include="$(OutDir)DeviceFiles\x86\nodeuwp.dll">
+			<Authenticode>Microsoft</Authenticode>
+		</FilesToSign>
+		<FilesToSign Include="$(OutDir)DeviceFiles\x86\uwp.node">
+			<Authenticode>Microsoft</Authenticode>
+		</FilesToSign>
+		<FilesToSign Include="$(OutDir)DeviceFiles\x64\nodeuwp.dll">
+			<Authenticode>Microsoft</Authenticode>
+		</FilesToSign>
+		<FilesToSign Include="$(OutDir)DeviceFiles\x64\uwp.node">
+			<Authenticode>Microsoft</Authenticode>
+		</FilesToSign>
+	</ItemGroup>
+	
+	<Target Name="BuildDeviceFiles" BeforeTargets="AfterBuild">
+		<Copy SourceFiles="\\scratch2\scratch\IoTDevX\BuildHelpers\TFbuild.ps1" DestinationFolder="."/>
+		<PropertyGroup>
+			<ScriptLocation>. .\TFbuild.ps1</ScriptLocation>
+			<Options>-build_devicefiles</Options>
+			<SignType>real</SignType>
+		</PropertyGroup>
+		<Exec Command="PowerShell -command &quot;&amp; { $(ScriptLocation)  $(Options) } &quot;" />
+	</Target>
+
+	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
+</Project>

--- a/TFinstallers.proj
+++ b/TFinstallers.proj
@@ -1,0 +1,37 @@
+<!-- This project is used by Team Foundation build. It builds the NTVS IoT Extension and the Node.js Tools for Windows IoT (Bundle) installers -->
+<!-- TFvsfiles.proj must be built before this project in the build definition** -->
+<!-- Node.js Tools for Windows IoT Team Foundation build sequence:
+    1. TFdevicefiles.proj
+    2. TFvsfiles.proj**
+    3. TFinstallers.proj
+    4. TFsignbundleinstaller.proj
+-->
+
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<OutputPath>bin\</OutputPath>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Compile Include="TFbuildstub.cs" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<FilesToSign Include="$(OutDir)Installers\NTVSIoTExtension.msi">
+			<Authenticode>MicrosoftSHA1</Authenticode>
+		</FilesToSign>
+		<FilesToSign Include="$(OutDir)Installers\WixBurnEngine\Node.js Tools for Windows IoT">
+			<Authenticode>MicrosoftSHA1</Authenticode>
+		</FilesToSign>
+	</ItemGroup>
+	
+	<Target Name="BuildInstaller" BeforeTargets="AfterBuild">
+		<PropertyGroup>
+			<ScriptLocation>. .\TFbuild.ps1</ScriptLocation>
+			<Options>-build_installer</Options>
+		</PropertyGroup>
+		<Exec Command="PowerShell -command &quot;&amp; { $(ScriptLocation) $(Options)} &quot;" />
+	</Target>
+	
+	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
+</Project>

--- a/TFsignbundleinstaller.proj
+++ b/TFsignbundleinstaller.proj
@@ -1,0 +1,34 @@
+<!-- This project is used by Team Foundation build. It signs the Node.js Tools for Windows IoT (Bundle) installer -->
+<!-- TFinstallers.proj must be built before this project in the build definition** -->
+<!-- Node.js Tools for Windows IoT Team Foundation build sequence:
+    1. TFdevicefiles.proj
+    2. TFvsfiles.proj
+    3. TFinstallers.proj**
+    4. TFsignbundleinstaller.proj
+-->
+
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+	  <OutputPath>bin\</OutputPath>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Compile Include="TFbuildstub.cs" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<FilesToSign Include="$(OutDir)Installers\Release\Node.js Tools for Windows IoT.exe">
+			<Authenticode>MicrosoftSHA1</Authenticode>
+		</FilesToSign>
+	</ItemGroup>
+	
+	<Target Name="BuildInstaller" BeforeTargets="AfterBuild">
+		<PropertyGroup>
+			<ScriptLocation>. .\TFbuild.ps1</ScriptLocation>
+			<Options>-sign_bundle_installer</Options>
+		</PropertyGroup>
+		<Exec Command="PowerShell -command &quot;&amp; { $(ScriptLocation) $(Options)} &quot;" />
+	</Target>
+	
+	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
+</Project>

--- a/TFvsfiles.proj
+++ b/TFvsfiles.proj
@@ -1,0 +1,39 @@
+<!-- This project is used by Team Foundation build. It builds the NTVS IoT Extension assemblies -->
+<!-- TFdevicefiles.proj must be built before this project in the build definition** -->
+<!-- Node.js Tools for Windows IoT Team Foundation build sequence:
+    1. TFdevicefiles.proj**
+    2. TFvsfiles.proj
+    3. TFinstallers.proj
+    4. TFsignbundleinstaller.proj
+-->
+
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<OutputPath>bin\</OutputPath>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Compile Include="TFbuildstub.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<FilesToSign Include="$(OutDir)Installers\FilesToSign\Microsoft.NodejsUwp.dll">
+			<Authenticode>Microsoft</Authenticode>
+			<StrongName>StrongName</StrongName>
+		</FilesToSign>
+		<FilesToSign Include="$(OutDir)Installers\FilesToSign\Microsoft.NodejsUwp.ProjectWizard.dll">
+			<Authenticode>Microsoft</Authenticode>
+			<StrongName>StrongName</StrongName>
+		</FilesToSign>
+	</ItemGroup>
+	
+	<Target Name="BuildInstaller"  BeforeTargets="AfterBuild">
+		<PropertyGroup>
+			<ScriptLocation>. .\TFbuild.ps1</ScriptLocation>
+			<Options>-build_vsfiles</Options>
+		</PropertyGroup>
+		<Exec Command="PowerShell -command &quot;&amp; { $(ScriptLocation) $(Options)} &quot;" />
+	</Target>
+	
+	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
+</Project>


### PR DESCRIPTION
This adds files (mainly project files) to fully build Node.js Tools for Windows IoT, using Team Foundation build.