### PR TITLE
Updating template json files + improving download failure message

### DIFF
--- a/Product/ProjectFlavor/Npm/NpmPatcher.cs
+++ b/Product/ProjectFlavor/Npm/NpmPatcher.cs
@@ -99,7 +99,8 @@ namespace Microsoft.NodejsUwp
         {
             if (e.Error != null)
             {
-                NpmHandler.PrintOutput(e.Error.Message, NpmOutputPane);
+                NpmHandler.PrintOutput(string.Format(CultureInfo.CurrentCulture, "Download failed: {0}",
+                    e.Error.Message), NpmOutputPane);
                 return;
             }
 

--- a/Product/ProjectTemplates/CylonUwp/package.json
+++ b/Product/ProjectTemplates/CylonUwp/package.json
@@ -9,7 +9,6 @@
     "email": ""
   },
   "dependencies": {
-    "request": "*",
     "cylon": "~1.1.0",
     "cylon-firmata": "~0.22.0",
     "cylon-gpio": "~0.26.0",

--- a/Product/ProjectTemplates/JohnnyFiveUwp/package.json
+++ b/Product/ProjectTemplates/JohnnyFiveUwp/package.json
@@ -9,7 +9,6 @@
     "email": ""
   },
   "dependencies": {
-    "request": "*",
     "johnny-five": "^0.9.14"
   }
 }


### PR DESCRIPTION
@alanch-ms quick CR. This mainly removes an unnecessary dependency for cylon and j5 templates.