### PR TITLE
Fixing serialport patcher

### DIFF
--- a/Product/ProjectFlavor/NodejsUwpProjectFlavor.cs
+++ b/Product/ProjectFlavor/NodejsUwpProjectFlavor.cs
@@ -169,7 +169,7 @@ namespace Microsoft.NodejsUwp
                     npmHandler.RunNpmDedupe(projectPath);
 
                     // Patch packages
-                    npmHandler.UpdateNpmPackages(projectPath, activeProj.ConfigurationManager.ActiveConfiguration.PlatformName);
+                    npmHandler.UpdateNpmPackages(projectPath);
                 }
             }
 

--- a/Product/ProjectFlavor/Npm/INpmPatcher.cs
+++ b/Product/ProjectFlavor/Npm/INpmPatcher.cs
@@ -38,7 +38,6 @@ namespace Microsoft.NodejsUwp
         /// </summary>
         /// <param name="projPath">Path of the project with the node_modules folder</param>
         /// <param name="pane">Visual Studio output window</param>
-        /// <param name="platform">x86, x64, or ARM</param>
-        void UpdatePackage(string projPath, IVsOutputWindowPane pane, string platform);
+        void UpdatePackage(string projPath, IVsOutputWindowPane pane);
     }
 }

--- a/Product/ProjectFlavor/Npm/NpmHandler.cs
+++ b/Product/ProjectFlavor/Npm/NpmHandler.cs
@@ -109,14 +109,13 @@ namespace Microsoft.NodejsUwp
         /// and use them to apply UWP patches to installed npm packages as required.
         /// </summary>
         /// <param name="projPath">Path of the Node.js UWP project</param>
-        /// <param name="platform">x86, x64, or ARM</param>
-        public void UpdateNpmPackages(string projPath, string platform)
+        public void UpdateNpmPackages(string projPath)
         {
             IEnumerable<Type> handlers = GetNpmHandlers();
             foreach(Type h in handlers)
             {
                 INpmPatcher npmHandler = (INpmPatcher)Activator.CreateInstance(h);
-                npmHandler.UpdatePackage(projPath, this.NpmOutputPane, platform);
+                npmHandler.UpdatePackage(projPath, this.NpmOutputPane);
             }
         }
 

--- a/Product/ProjectFlavor/Npm/NpmPatcher.cs
+++ b/Product/ProjectFlavor/Npm/NpmPatcher.cs
@@ -30,11 +30,6 @@ namespace Microsoft.NodejsUwp
         private IVsOutputWindowPane NpmOutputPane { get; set; }
 
         /// <summary>
-        /// Platform architecture of target where package will be deployed to.
-        /// </summary>
-        private string Platform { get; set; }
-
-        /// <summary>
         /// Name of the npm package.
         /// </summary>
         private string PackageName { get; set; }
@@ -55,10 +50,9 @@ namespace Microsoft.NodejsUwp
         /// <param name="uri">Uri of zip file with patch</param>
         /// <param name="destPath">Patch download destination</param>
         /// <param name="pane">Visual Studio output pane to display messages</param>
-        /// <param name="platform">Platform architecture of target where package will be deployed to</param>
         /// <param name="packageName">Name of the npm package</param>
         /// <param name="patchMap">Maps the files in in patch to their destinations</param>
-        internal void UpdatePackage(Uri uri, string destPath, IVsOutputWindowPane pane, string platform, string packageName, Dictionary<string, string> patchMap)
+        internal void UpdatePackage(Uri uri, string destPath, IVsOutputWindowPane pane, string packageName, Dictionary<string, string> patchMap)
         {
             ProjectPath = string.Format(CultureInfo.CurrentCulture, "{0}\\", destPath);
 
@@ -69,7 +63,6 @@ namespace Microsoft.NodejsUwp
             }
 
             NpmOutputPane = pane;
-            Platform = platform;
             PackageName = packageName;
             PatchMap = patchMap;
             PatchUri = uri;
@@ -160,6 +153,8 @@ namespace Microsoft.NodejsUwp
                     {
                         Directory.CreateDirectory(dest.DirectoryName);
                     }
+                    NpmHandler.PrintOutput(string.Format(CultureInfo.CurrentCulture, "Copying {0} to {1}",
+                        src.FullName, dest.FullName), NpmOutputPane);
                     File.Copy(src.FullName, dest.FullName, true);
                 }
                 catch (Exception ex)

--- a/Product/ProjectFlavor/Npm/NpmPatcher.cs
+++ b/Product/ProjectFlavor/Npm/NpmPatcher.cs
@@ -99,7 +99,8 @@ namespace Microsoft.NodejsUwp
         {
             if (e.Error != null)
             {
-                NpmHandler.PrintOutput(e.Error.Message, NpmOutputPane);
+                NpmHandler.PrintOutput(string.Format(CultureInfo.CurrentCulture, "Download failed: {0}",
+                    e.Error.Message), NpmOutputPane);
                 return;
             }
 

--- a/Product/ProjectFlavor/Npm/SerialportNpmPatcher.cs
+++ b/Product/ProjectFlavor/Npm/SerialportNpmPatcher.cs
@@ -39,23 +39,18 @@ namespace Microsoft.NodejsUwp
         private const string NODE_MODULE_VERSION = "v47";
         private const string Name = "serialport";
         private const string PatchUri = "http://aka.ms/spc_zip";
-        private enum Platforms { arm, x86, x64 }
+        private enum Platform { arm, x86, x64 }
 
         public void UpdatePackage(string projPath, IVsOutputWindowPane pane)
         {
             Dictionary<string, string> patchMap = new Dictionary<string, string>();
-            string altPlatName = string.Empty;
 
             patchMap.Add("\\uwp\\serialport.js", "\\node_modules\\serialport\\serialport.js");
-            foreach (string plat in Enum.GetNames(typeof(Platforms)))
+            foreach (Platform platform in Enum.GetValues(typeof(Platform)))
             {
-                altPlatName = plat;
-                if (0 == string.Compare(plat, Platforms.x86.ToString("g")))
-                {
-                    altPlatName = "ia32";
-                }
-                patchMap.Add(string.Format(CultureInfo.CurrentCulture, "\\uwp\\{0}\\serialport.node", plat), string.Format(CultureInfo.CurrentCulture,
-                    "\\node_modules\\serialport\\build\\Release\\node-{0}-win32-{1}\\serialport.node", NODE_MODULE_VERSION, altPlatName));      
+                string platformStr = platform.ToString();
+                patchMap.Add(string.Format(CultureInfo.CurrentCulture, "\\uwp\\{0}\\serialport.node", platformStr), string.Format(CultureInfo.CurrentCulture,
+                    "\\node_modules\\serialport\\build\\Release\\node-{0}-win32-{1}\\serialport.node", NODE_MODULE_VERSION, (platform == Platform.x86) ? "ia32" : platformStr));      
             }
 
             NpmPatcher npmPatcher = new NpmPatcher();

--- a/Product/ProjectFlavor/Npm/SerialportNpmPatcher.cs
+++ b/Product/ProjectFlavor/Npm/SerialportNpmPatcher.cs
@@ -39,16 +39,27 @@ namespace Microsoft.NodejsUwp
         private const string NODE_MODULE_VERSION = "v47";
         private const string Name = "serialport";
         private const string PatchUri = "http://aka.ms/spc_zip";
+        private enum Platforms { arm, x86, x64 }
 
-        public void UpdatePackage(string projPath, IVsOutputWindowPane pane, string platform)
+        public void UpdatePackage(string projPath, IVsOutputWindowPane pane)
         {
             Dictionary<string, string> patchMap = new Dictionary<string, string>();
-            patchMap.Add(string.Format(CultureInfo.CurrentCulture, "\\uwp\\{0}\\serialport.node", platform), string.Format(CultureInfo.CurrentCulture,
-                "\\node_modules\\serialport\\build\\Release\\node-{0}-win32-{1}\\serialport.node", NODE_MODULE_VERSION, platform));
+            string altPlatName = string.Empty;
+
             patchMap.Add("\\uwp\\serialport.js", "\\node_modules\\serialport\\serialport.js");
+            foreach (string plat in Enum.GetNames(typeof(Platforms)))
+            {
+                altPlatName = plat;
+                if (0 == string.Compare(plat, Platforms.x86.ToString("g")))
+                {
+                    altPlatName = "ia32";
+                }
+                patchMap.Add(string.Format(CultureInfo.CurrentCulture, "\\uwp\\{0}\\serialport.node", plat), string.Format(CultureInfo.CurrentCulture,
+                    "\\node_modules\\serialport\\build\\Release\\node-{0}-win32-{1}\\serialport.node", NODE_MODULE_VERSION, altPlatName));      
+            }
 
             NpmPatcher npmPatcher = new NpmPatcher();
-            npmPatcher.UpdatePackage(new Uri(PatchUri), projPath, pane, platform, Name, patchMap);
+            npmPatcher.UpdatePackage(new Uri(PatchUri), projPath, pane, Name, patchMap);
         }
     }
 }

--- a/Product/ProjectTemplates/CylonUwp/package.json
+++ b/Product/ProjectTemplates/CylonUwp/package.json
@@ -9,7 +9,6 @@
     "email": ""
   },
   "dependencies": {
-    "request": "*",
     "cylon": "~1.1.0",
     "cylon-firmata": "~0.22.0",
     "cylon-gpio": "~0.26.0",

--- a/Product/ProjectTemplates/JohnnyFiveUwp/package.json
+++ b/Product/ProjectTemplates/JohnnyFiveUwp/package.json
@@ -9,7 +9,6 @@
     "email": ""
   },
   "dependencies": {
-    "request": "*",
     "johnny-five": "^0.9.14"
   }
 }


### PR DESCRIPTION
- Added some more messages for the output window to help with debugging.
- Removed specifying platform for patcher. Patch should install files necessary for all platforms so that user doesn't need to run the update for each platform selected.
- Removed unnecessary request dependency from json in J5 and Cylon templates.

@alanch-ms please CR.