### PR TITLE
Use package.json file to get startup info

### DIFF
--- a/Product/NodejsUwp.csproj
+++ b/Product/NodejsUwp.csproj
@@ -323,7 +323,6 @@
       <SubType>Designer</SubType>
     </ZipProject>
     <ZipProject Include="ProjectTemplates\JohnnyFiveUwp\package.json" />
-    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
@@ -377,6 +376,10 @@
     <ZipProject Include="ProjectTemplates\JohnnyFiveUwp\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <ZipProject Include="ProjectTemplates\JohnnyFiveUwp\StoreLogo.png" />
     <ZipProject Include="ProjectTemplates\JohnnyFiveUwp\Wide310x150Logo.scale-200.png" />
+    <Content Include="Newtonsoft.Json.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <Content Include="VSTemplateStore.pkgdef" />
     <VSCTCompile Include="NodejsUwp.vsct">
       <ResourceName>1000</ResourceName>

--- a/Product/NodejsUwp.csproj
+++ b/Product/NodejsUwp.csproj
@@ -152,6 +152,10 @@
       <Private>false</Private>
       <HintPath>$(DevEnvDir)Extensions\Microsoft\Windows Azure Tools\Common\Microsoft.VisualStudio.WindowsAzure.CommonAzureTools.Contracts.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System">
@@ -319,6 +323,8 @@
       <SubType>Designer</SubType>
     </ZipProject>
     <ZipProject Include="ProjectTemplates\JohnnyFiveUwp\package.json" />
+    <None Include="app.config" />
+    <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/Product/ProjectFlavor/NodejsUwpProjectFlavorCfg.cs
+++ b/Product/ProjectFlavor/NodejsUwpProjectFlavorCfg.cs
@@ -1358,19 +1358,10 @@ namespace Microsoft.NodejsUwp
 
         private bool UpdatePackageJsonScript()
         {
-            // Get project directory
-            string projectDir = GetStringPropertyValue("ProjectDir");
-
-            // Get package.json text       
-            string packageJsonFilePath = Path.Combine(projectDir, "package.json");
-            JObject json;
-            try
+            string path = Path.Combine(GetStringPropertyValue("ProjectDir"), "package.json");
+            JObject json = LoadPackageJson(path);
+            if(null == json)
             {
-                json = JObject.Parse(File.ReadAllText(packageJsonFilePath));
-            }
-            catch (Exception e)
-            {
-                MessageBox.Show(e.Message, "NTVS IoT Extension", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
@@ -1401,34 +1392,50 @@ namespace Microsoft.NodejsUwp
             scriptsObj.Add("start", startArgs);
             json.Add("scripts", scriptsObj);
 
-            // Save changes
-            File.WriteAllText(packageJsonFilePath, json.ToString());
-            return true;
+            return SavePackageJson(path, json);
         }
 
         private bool UpdatePackageJsonPlatform()
         {
-            // Get project directory
-            string projectDir = GetStringPropertyValue("ProjectDir");
-
-            // Get package.json text       
-            string packageJsonFilePath = Path.Combine(projectDir, "package.json");
-            JObject json;
-            try
+            string path = Path.Combine(GetStringPropertyValue("ProjectDir"), "package.json");
+            JObject json = LoadPackageJson(path);
+            if (null == json)
             {
-                json = JObject.Parse(File.ReadAllText(packageJsonFilePath));
-            }
-            catch (Exception e)
-            {
-                MessageBox.Show(e.Message, "NTVS IoT Extension", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
             // Add platform to package.json for npm to use
             json["target_arch"] = GetPlatform();
 
-            // Save changes
-            File.WriteAllText(packageJsonFilePath, json.ToString());
+            return SavePackageJson(path, json);
+        }
+
+        JObject LoadPackageJson(string path)
+        {          
+            JObject json;
+            try
+            {
+                json = JObject.Parse(File.ReadAllText(path));
+            }
+            catch (Exception e)
+            {
+                MessageBox.Show(e.Message, "NTVS IoT Extension", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return null;
+            }
+            return json;
+        }
+
+        bool SavePackageJson(string path, JObject json)
+        {
+            try
+            {
+                File.WriteAllText(path, json.ToString());
+            }
+            catch (Exception e)
+            {
+                MessageBox.Show(e.Message, "NTVS IoT Extension", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return false;
+            }
             return true;
         }
 

--- a/Product/ProjectTemplates/CylonUwp/package.json
+++ b/Product/ProjectTemplates/CylonUwp/package.json
@@ -13,7 +13,9 @@
     "cylon-firmata": "~0.22.0",
     "cylon-gpio": "~0.26.0",
     "cylon-i2c": "~0.22.0"
-  }
+  },
+  "target_arch": "arm",
+  "platform": "uwp"
 }
 
 

--- a/Product/ProjectTemplates/Express4Uwp/package.json
+++ b/Product/ProjectTemplates/Express4Uwp/package.json
@@ -19,5 +19,7 @@
     "debug": "~2.0.0",
     "jade": "~1.6.0",
     "stylus": "0.42.3"
-  }
+  },
+  "target_arch": "arm",
+  "platform": "uwp"
 }

--- a/Product/ProjectTemplates/JohnnyFiveUwp/package.json
+++ b/Product/ProjectTemplates/JohnnyFiveUwp/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "johnny-five": "^0.9.14"
-  }
+  },
+  "target_arch": "arm",
+  "platform": "uwp"
 }
 
 

--- a/Product/ProjectTemplates/WebServerUwp/package.json
+++ b/Product/ProjectTemplates/WebServerUwp/package.json
@@ -6,5 +6,7 @@
   "author": {
     "name": "$username$",
     "email": ""
-  }
+  },
+  "target_arch": "arm",
+  "platform": "uwp"
 }

--- a/Product/packages.config
+++ b/Product/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+</packages>

--- a/Product/source.extension.vsixmanifest
+++ b/Product/source.extension.vsixmanifest
@@ -16,5 +16,6 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="ProjectWizard" Path="|ProjectWizard|" AssemblyName="|ProjectWizard;AssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="%CurrentProject%" d:TargetPath="|%CurrentProject%;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Newtonsoft.Json.dll" AssemblyName="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
   </Assets>
 </PackageManifest>

--- a/Setup/NodejsUwpFiles/Microsoft.NodejsUwp.targets
+++ b/Setup/NodejsUwpFiles/Microsoft.NodejsUwp.targets
@@ -24,67 +24,6 @@
     <ProjectHome Condition="'$(ProjectHome)' == ''">.</ProjectHome>
     <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
   </PropertyGroup>
-  
-  <UsingTask TaskName="CreateStartupInfoFileTask" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll" >
-    <ParameterGroup>
-      <Config Required="true"/>
-      <Plat Required="true"/>
-      <StartFile Required="true"/>
-      <ProjFile Required="true"/>
-      <OutPath Required="true"/>
-    </ParameterGroup>
-    <Task>
-      <Reference Include="System.Xml"/>
-      <Reference Include="System.Xml.Linq"/>
-      <Using Namespace="System.Xml"/>
-      <Using Namespace="System.Xml.Linq"/>
-      <Using Namespace="System.IO"/>
-      <Using Namespace="System.Globalization"/>
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-          XmlDocument doc = new XmlDocument();
-          doc.Load(ProjFile);
-          XmlNode VSNode = doc.DocumentElement["ProjectExtensions"].FirstChild;
-          string nodeExeArguments = string.Empty;
-          string scriptArguments = string.Empty;
-
-          if(null != VSNode) {
-            foreach (XmlNode FPNode in VSNode) {
-              if (0 == String.Compare(FPNode.Attributes["Configuration"].InnerText, Config) && 
-                  0 == String.Compare(FPNode.Attributes["Platform"].InnerText, Plat)) {
-                 if(null != FPNode.FirstChild) {
-                   foreach (XmlNode PropNode in FPNode.FirstChild) {
-                      if(0 == String.Compare(PropNode.Name, "NodeExeArguments")) {
-                        nodeExeArguments = PropNode.InnerText;
-                      }
-                      if (0 == String.Compare(PropNode.Name, "ScriptArguments")) {
-                        scriptArguments = PropNode.InnerText;
-                      }
-                   }
-                 }
-              }
-            }
-          }
-
-          XDocument xdoc = new XDocument();
-
-          XElement srcTree = new XElement("StartupInfo",
-            new XElement("Script", StartFile),
-            new XElement("NodeOptions", nodeExeArguments),
-            new XElement("ScriptArgs", scriptArguments)
-          );
-
-          xdoc.Add(srcTree);
-          string startupInfoFilePath = string.Format(CultureInfo.InvariantCulture, "{0}{1}", OutPath, "startupinfo.xml");
-          xdoc.Save(startupInfoFilePath);
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <Target Name="CreateStartupInfoFileTarget"  BeforeTargets="CoreCompile">      
-      <CreateStartupInfoFileTask Config="$(Configuration)" Plat="$(Platform)" StartFile="$(StartupFile)" ProjFile="$(MSBuildProjectFullPath)" OutPath="$(OutputPath)"/>
-  </Target>
 
   <!-- Include uwp.node to project when building to allow access to UWP namespaces -->
   <Target Name="CopyUWPAddon" BeforeTargets="CoreCompile">
@@ -104,9 +43,6 @@
   </ItemGroup>
   <ItemGroup>
     <NodeHostFiles Include="$(NodechUWPSDKPath)\$(Platform)\*.dll"/>
-  </ItemGroup>
-  <ItemGroup>
-    <NodeHostFiles Include="$(OutputPath)startupinfo.xml"/>
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This change corresponds to https://github.com/ms-iot/node-uwp-wrapper/pull/27. Instead of saving startup info in a custom startupinfo.xml, we use the package.json file.