### PR TITLE
Updates for v1.5.5

### DIFF
--- a/Product/NodejsUwp.csproj
+++ b/Product/NodejsUwp.csproj
@@ -153,8 +153,8 @@
       <HintPath>$(DevEnvDir)Extensions\Microsoft\Windows Azure Tools\Common\Microsoft.VisualStudio.WindowsAzure.CommonAzureTools.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -377,7 +377,7 @@
     <ZipProject Include="ProjectTemplates\JohnnyFiveUwp\StoreLogo.png" />
     <ZipProject Include="ProjectTemplates\JohnnyFiveUwp\Wide310x150Logo.scale-200.png" />
     <Content Include="Newtonsoft.Json.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="VSTemplateStore.pkgdef" />
@@ -465,4 +465,7 @@
       </ZipProject>
     </ItemGroup>
   </Target>
+  <PropertyGroup>
+    <PreBuildEvent>copy $(SolutionDir)packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll $(ProjectDir) /y</PreBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Product/NodejsUwp.csproj
+++ b/Product/NodejsUwp.csproj
@@ -377,7 +377,7 @@
     <ZipProject Include="ProjectTemplates\JohnnyFiveUwp\StoreLogo.png" />
     <ZipProject Include="ProjectTemplates\JohnnyFiveUwp\Wide310x150Logo.scale-200.png" />
     <Content Include="Newtonsoft.Json.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="VSTemplateStore.pkgdef" />

--- a/Product/source.extension.vsixmanifest
+++ b/Product/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="0BBF5C2B-3093-431D-8A14-47AC07CFFABF" Version="1.0" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>NTVS IoT Extension</DisplayName>
+    <DisplayName>NTVS UWP Extension</DisplayName>
     <Description>VS package for building Node.js UWP applications</Description>
   </Metadata>
   <Installation InstalledByMsi="true">

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ In order to deploy an app to your PC or Phone, you must first enable Embedded Mo
 You also need to turn on `Developer mode`. This can be done on the `Settings -> Update & Security -> For Developers` page.
 
 
+##Intellisense for UWP API
+IntelliSense is available for UWP APIs through the [ES6 Intellisense](https://github.com/Microsoft/nodejstools/wiki/ES6-IntelliSense-Preview-in-NTVS-1.1) feature in NTVS 1.2.
+
+  ![capture](https://cloud.githubusercontent.com/assets/8389594/14468105/227e9760-0093-11e6-98c2-cc4b8dcd05e3.PNG)
+
+To enable IntelliSense in your project:
+* Ensure you have the 'ES6 IntelliSense Preview' option set under `Tools -> Options -> Text Editor -> Node.js -> IntelliSense`
+* Right click on your project in the Solution Explorer and select 'Open Command Prompt Here...'
+* Run `npm install typings -g`
+* Run `typings install dt~winrt-uwp --global`
+
+
 ##Creating new issues
 Please follow the guidelines below when creating new issues:
 * Use a descriptive title that identifies the issue to be addressed or the requested feature (e.g., "Feature F should report ABC when XYZ is used in DEF").

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ These options can be entered in the 'Other npm arguments' textbox in the `Instal
 
 **Notes:**
 * The version of npm used by the extension is included with the [node-chakra installer](https://aka.ms/node-chakra-installer) which is bundled in the
-[release](https://aka.ms/node-chakra-installer)
+[release](https://aka.ms/ntvsiotlatest)
 * The [uwp](https://github.com/microsoft/node-uwp) package will always be included in your project automatically so there is no need to install it.
 * Existing npm packages are likely to use APIs that are banned in UWP apps
 (i.e. will not pass [WACK certification](https://developer.microsoft.com/en-us/windows/develop/app-certification-kit)). In these cases, support for UWP is 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,97 @@ required before they can build successfully. The serialport fork [here](https://
 can be done.
 
 
+##Unsupported Node.js API
+Since we are running Node in an UWP app the are a few internal modules/functions that will either work a little differently from what you're used to (i.e. with console node.exe)
+or will be unsupported due to the nature of UWP applications. Anything that is not listed here is expected to work normally.
+
+####Child-Process
+Unsupported
+
+####Cluster
+Unsupported
+
+####Console 
+console.* will output messages to the Visual Studio output window. The `--debug` option needs to be passed to node for this to work.
+You can also use the `--use-logger` option to redirect console output to a file in the 
+[local storage path](https://msdn.microsoft.com/en-us/library/windows/apps/windows.storage.applicationdata.localfolder.aspx) of the application 
+(C:\Data\Users\DefaultAccount\AppData\Local\Packages\&lt;Your Project Name&gt;_&lt;Publisher Hash String&gt;\LocalState\nodeuwp.log).
+
+####Debugger 
+Unsupported. For debugging, the Visual Studio JavaScript debugger is used.
+
+####File System
+Read/write permission is automatically granted for accessing files in the [local storage path](https://msdn.microsoft.com/en-us/library/windows/apps/windows.storage.applicationdata.localfolder.aspx) 
+of your application. You can also read files from the application [install path](https://msdn.microsoft.com/en-us/library/windows/apps/windows.applicationmodel.package.installedlocation.aspx). 
+The storage and install path can be retrieved using `fs.uwpstoragedir`, `fs.uwpstoragedirSync`, `fs.uwpinstalldir`, and `fs.uwpinstalldirSync`. 
+You may also access folders associated with [app capability declarations](https://msdn.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations).
+The following fs functions are not supported:
+* `fs.link`
+* `fs.linkSync`
+* `fs.readlink`
+* `fs.readlinkSync`
+* `fs.symlink`
+* `fs.symlinkSync`
+* `fs.unlink`
+* `fs.unlinkSync`
+* `fs.realpath`
+* `fs.realpathSync`
+* `fs.watch`
+* `fs.watchFile`
+
+####OS
+The following os functions are not supported:
+* `os.cpus`
+* `os.homedir`
+* `os.tmpdir`
+* `os.userInfo`
+
+####Process
+The following process functions/properties are not supported:
+* `process.connected`
+* `process.cpuUsage` (bug: this should work using [ProcessCpuUsage](https://msdn.microsoft.com/en-us/library/windows/apps/windows.system.diagnostics.processcpuusage.aspx))
+* `process.disconnect`
+* `process.env`
+* `process.getegid`
+* `process.geteuid`
+* `process.getgid`
+* `process.getgroups`
+* `process.getuid`
+* `process.initgroups`
+* `process.kill`
+* `process.memoryUsage` (bug: this should work using [MemoryManager](https://msdn.microsoft.com/en-us/library/windows.system.memorymanager.aspx))
+* `process.send`
+* `process.setegid`
+* `process.seteuid`
+* `process.setgid`
+* `process.setgroups`
+* `process.setuid`
+* `process.stdin`
+* `process.umask`
+
+####Readline
+Unsupported
+
+####REPL
+Unsupported
+
+####TTY
+Unsupported
+
+
+##Building and deploying an app package (AppX)
+You have the option to build and deploy your app without using the Visual Studio UI. To do this, follow the instructions below:
+
+* Open Developer Command Prompt for VS 2015.
+* Navigate to your project.
+* Run `msbuild <Your solution name>.sln /p:configuration=release /p:platform=<arm | x86 | x64 >` (use arm for Raspberry Pi 2 or 3 and x86 for MBM).
+* After running the command above, you should see a new folder with the AppX in: \Your project root\AppPackages.
+* Once you have created an AppX, you can use [Windows Device Portal to deploy it](https://developer.microsoft.com/en-us/windows/iot/docs/deviceportal) to your device.
+* In a SSH or PowerShell window connected to your device, run `iotstartup list` to get the full package name of your app.
+* Then run `iotstartup add headless <your package name>`
+* Run `shutdown /r /t 0` to reboot your device. When the reboot completes, the app will be running.
+
+
 ##Creating new issues
 Please follow the guidelines below when creating new issues:
 * Use a descriptive title that identifies the issue to be addressed or the requested feature (e.g., "Feature F should report ABC when XYZ is used in DEF").

--- a/README.md
+++ b/README.md
@@ -31,13 +31,9 @@ Other samples to try out:
 * [Send data from a light sensor to Azure](https://developer.microsoft.com/en-us/windows/iot/samples/azuredatauploader)
 
 
-##Contributing
-The NTVS UWP Extension code is covered by the [MIT license](http://opensource.org/licenses/MIT). There is no formal style-guide, but contributors should try to match the style of the file they are editing. 
-Feel free to reach out if you need a hand in starting to tackle an issue. For new functionality, please contact us first so we can coordinate efforts (e.g. to avoid duplication of work, roadmap fit, etc.).
-Since this code is under the MIT license, all contributions will be made under that license as well. Please don’t submit anything with any other licensing statements. If you want to make a contribution 
-that includes code that you received under a different license, please let us know and we can figure out what to do. Please be sure that you have the right to make your contribution, including clearance 
-from your employer if applicable. You must sign the [Microsoft Contributor License Agreement (CLA)](https://cla.microsoft.com/) before submitting your pull-request. The CLA only needs to be completed once 
-to cover all Microsoft OSS projects.
+##Deployment to PC and Phone
+In order to deploy an app to your PC or Phone, you must first enable Embedded Mode. See [this](https://developer.microsoft.com/en-us/windows/iot/docs/embeddedmode) page for instructions on how to do that.
+You also need to turn on `Developer mode`. This can be done on the `Settings -> Update & Security -> For Developers` page.
 
 
 ##Creating new issues
@@ -50,7 +46,16 @@ Please follow the guidelines below when creating new issues:
     * Specify any relevant exception messages and stack traces.
 	
 
-##Build and debug
+##Contributing
+The NTVS UWP Extension code is covered by the [MIT license](http://opensource.org/licenses/MIT). There is no formal style-guide, but contributors should try to match the style of the file they are editing. 
+Feel free to reach out if you need a hand in starting to tackle an issue. For new functionality, please contact us first so we can coordinate efforts (e.g. to avoid duplication of work, roadmap fit, etc.).
+Since this code is under the MIT license, all contributions will be made under that license as well. Please don’t submit anything with any other licensing statements. If you want to make a contribution 
+that includes code that you received under a different license, please let us know and we can figure out what to do. Please be sure that you have the right to make your contribution, including clearance 
+from your employer if applicable. You must sign the [Microsoft Contributor License Agreement (CLA)](https://cla.microsoft.com/) before submitting your pull-request. The CLA only needs to be completed once 
+to cover all Microsoft OSS projects.
+
+
+##Debugging the Extension
 As a contributor, you can use the steps below to set up your PC to build and debug the code in this repository.
 
 **Prerequisites:** Visual Studio 2015 and Visual Studio 2015 SDK need to be installed.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You have the option to build and deploy your app without using the Visual Studio
 
 * Open Developer Command Prompt for VS 2015.
 * Navigate to your project.
-* Run `msbuild <Your solution name>.sln /p:configuration=release /p:platform=<arm | x86 | x64 >` (use arm for Raspberry Pi 2 or 3 and x86 for MBM).
+* Run `msbuild <Your solution name>.sln /p:configuration=release /p:platform=<arm | x86 | x64 >` (use arm for Raspberry Pi 2 or 3 and x86 for MBM or DragonBoard).
 * After running the command above, you should see a new folder with the AppX in: \Your project root\AppPackages.
 * Once you have created an AppX, you can use [Windows Device Portal to deploy it](https://developer.microsoft.com/en-us/windows/iot/docs/deviceportal) to your device.
 * In a SSH or PowerShell window connected to your device, run `iotstartup list` to get the full package name of your app.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ To enable IntelliSense in your project:
 * Run `typings install dt~winrt-uwp --global`
 
 
+##Installing npm packages
+Instructions on how to use the NTVS npm UI can be found [here](https://github.com/Microsoft/nodejstools/wiki/npm-Integration).
+If you are installing a native package or a package with native dependencies, the following is required.
+In the 'Other npm arguments' textbox in the `Install New npm packages` dialog, you can enter `--target_arch=arm|x86|x64 --node_uwp_dll` to target UWP. Example:
+
+  ![capture](https://cloud.githubusercontent.com/assets/8389594/18188096/ecab2eb4-7063-11e6-932f-d6b37aa280ea.PNG)
+
+Note:
+* The [uwp](https://github.com/microsoft/node-uwp) native addon will always be included in your project automatically so there is no need to install it.
+* Existing npm packages are likely to use APIs that are banned in UWP apps. In this case support for UWP would need to be added to the package. The serialport fork
+[here](https://github.com/ms-iot/node-serialport/tree/uwp) gives an example of how this can be done without affecting existing platforms.
+
+
 ##Creating new issues
 Please follow the guidelines below when creating new issues:
 * Use a descriptive title that identifies the issue to be addressed or the requested feature (e.g., "Feature F should report ABC when XYZ is used in DEF").

--- a/README.md
+++ b/README.md
@@ -50,15 +50,22 @@ To enable IntelliSense in your project:
 
 ##Installing npm packages
 Instructions on how to use the NTVS npm UI can be found [here](https://github.com/Microsoft/nodejstools/wiki/npm-Integration).
-If you are installing a native package or a package with native dependencies, the following is required.
-In the 'Other npm arguments' textbox in the `Install New npm packages` dialog, you can enter `--target_arch=arm|x86|x64 --node_uwp_dll` to target UWP. Example:
+If you are installing a native package or a package with native dependencies, there are two options required to target UWP:
+* `--target_arch`: The processor architecture (arm, x86, or x64) of the device the package will be running on
+* `--node_uwp_dll`: Tells npm that you are building the package for use in a UWP app
+
+These options can be entered in the 'Other npm arguments' textbox in the `Install New npm packages` dialog:
 
   ![capture](https://cloud.githubusercontent.com/assets/8389594/18188096/ecab2eb4-7063-11e6-932f-d6b37aa280ea.PNG)
 
-Note:
-* The [uwp](https://github.com/microsoft/node-uwp) native addon will always be included in your project automatically so there is no need to install it.
-* Existing npm packages are likely to use APIs that are banned in UWP apps. In this case support for UWP would need to be added to the package. The serialport fork
-[here](https://github.com/ms-iot/node-serialport/tree/uwp) gives an example of how this can be done without affecting existing platforms.
+**Notes:**
+* The version of npm used by the extension is included with the [node-chakra installer](https://aka.ms/node-chakra-installer) which is bundled in the
+[release](https://aka.ms/node-chakra-installer)
+* The [uwp](https://github.com/microsoft/node-uwp) package will always be included in your project automatically so there is no need to install it.
+* Existing npm packages are likely to use APIs that are banned in UWP apps
+(i.e. will not pass [WACK certification](https://developer.microsoft.com/en-us/windows/develop/app-certification-kit)). In these cases, support for UWP is 
+required before they can build successfully. The serialport fork [here](https://github.com/ms-iot/node-serialport/tree/uwp) gives an example of how this 
+can be done.
 
 
 ##Creating new issues

--- a/Setup/NodejsUwpFiles/NodejsUwpFiles.proj
+++ b/Setup/NodejsUwpFiles/NodejsUwpFiles.proj
@@ -12,6 +12,7 @@
         <!-- Core extension -->
         <File Include="Microsoft.NodejsUwp.dll" />
         <File Include="Microsoft.NodejsUwp.ProjectWizard.dll" />
+        <File Include="Newtonsoft.Json.dll" />
 
         <!-- Resources -->
         <File Include="..\Icons\NodeJS.ico" />

--- a/Setup/NodejsUwpFiles/NodejsUwpFiles.wxs
+++ b/Setup/NodejsUwpFiles/NodejsUwpFiles.wxs
@@ -50,6 +50,9 @@
       <Component Guid="{8D40ED61-96A4-480F-9794-96DF63259866}" Directory="x86">
         <File Id="node_x86" Source="$(var.Release_Path)x86\node.dll" KeyPath='yes' />
       </Component>
+      <Component Guid="{BEA9D1D6-02F9-4A1A-B0B7-15C405FE1063}" Directory="x86">
+        <File Id="nodelib_x86" Source="$(var.Release_Path)x86\node.lib" KeyPath='yes' />
+      </Component>
       <Component Guid="{10EFA5AB-B452-4BC4-8932-5186F23F1550}" Directory="x86">
         <File Id="uwp_x86" Source="$(var.Release_Path)x86\uwp.node" KeyPath='yes' />
       </Component>
@@ -61,6 +64,9 @@
       <Component Guid="{C54F84EC-9B85-4AC1-AFD7-6B9342986756}" Directory="ARM">
         <File Id="node_ARM" Source="$(var.Release_Path)ARM\node.dll" KeyPath='yes' />
       </Component>
+      <Component Guid="{51FB2567-0D0D-4081-95B5-69D042051DB4}" Directory="ARM">
+        <File Id="nodelib_ARM" Source="$(var.Release_Path)ARM\node.lib" KeyPath='yes' />
+      </Component>
       <Component Guid="{C0A507C0-F07E-4C67-8566-5FFB0DA61D2F}" Directory="ARM">
         <File Id="uwp_ARM" Source="$(var.Release_Path)ARM\uwp.node" KeyPath='yes' />
       </Component>
@@ -71,6 +77,9 @@
       </Component>
       <Component Guid="{0384B5B5-57FA-4B37-9421-FCC6972E47D1}" Directory="x64">
         <File Id="node_x64" Source="$(var.Release_Path)x64\node.dll" KeyPath='yes' />
+      </Component>
+      <Component Guid="{2EB9A4E9-E7E2-4D31-B90F-6E2EC0D73B97}" Directory="x64">
+        <File Id="nodelib_x64" Source="$(var.Release_Path)x64\node.lib" KeyPath='yes' />
       </Component>
       <Component Guid="{EB52ED9A-5918-4EB5-BB9E-9DCD752182EA}" Directory="x64">
         <File Id="uwp_x64" Source="$(var.Release_Path)x64\uwp.node" KeyPath='yes' />


### PR DESCRIPTION
* Include node.lib in installer. It will be used by npm to build addons targeting uwp (https://github.com/ms-iot/node/blob/chakra-uwp/deps/npm/node_modules/node-gyp/addon.gypi#L3)
* Fix problem with Newtonsoft.Json not getting copied during installation.
* README update.